### PR TITLE
Added ConfirmationStatement to CompanyProfile

### DIFF
--- a/src/LiberisLabs.CompaniesHouse/LiberisLabs.CompaniesHouse.csproj
+++ b/src/LiberisLabs.CompaniesHouse/LiberisLabs.CompaniesHouse.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Response\CompanyFiling\FilingHistoryItemAnnotation.cs" />
     <Compile Include="Response\CompanyFiling\FilingHistoryItemAssociatedFiling.cs" />
     <Compile Include="Response\CompanyFiling\Links.cs" />
+    <Compile Include="Response\CompanyProfile\ConfirmationStatement.cs" />
     <Compile Include="Response\Officers\Officers.cs" />
     <Compile Include="Response\ResolutionCategory.cs" />
     <Compile Include="Response\FilingSubcategory.cs" />

--- a/src/LiberisLabs.CompaniesHouse/Response/CompanyProfile/CompanyProfile.cs
+++ b/src/LiberisLabs.CompaniesHouse/Response/CompanyProfile/CompanyProfile.cs
@@ -20,6 +20,9 @@ namespace LiberisLabs.CompaniesHouse.Response.CompanyProfile
         [JsonProperty(PropertyName = "annual_return")]
         public AnnualReturn AnnualReturn { get; set; }
 
+        [JsonProperty(PropertyName = "confirmation_statement")]
+        public ConfirmationStatement ConfirmationStatement { get; set; }
+
         [JsonProperty(PropertyName = "can_file")]
         public bool? CanFile { get; set; }
 

--- a/src/LiberisLabs.CompaniesHouse/Response/CompanyProfile/ConfirmationStatement.cs
+++ b/src/LiberisLabs.CompaniesHouse/Response/CompanyProfile/ConfirmationStatement.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace LiberisLabs.CompaniesHouse.Response.CompanyProfile
+{
+    public class ConfirmationStatement
+    {
+        [JsonProperty(PropertyName = "last_made_up_to")]
+        public DateTime? LastMadeUpTo { get; set; }
+
+        [JsonProperty(PropertyName = "next_due")]
+        public DateTime? NextDue { get; set; }
+
+        [JsonProperty(PropertyName = "next_made_up_to")]
+        public DateTime? NextMadeUpTo { get; set; }
+
+        [JsonProperty(PropertyName = "overdue")]
+        public bool? Overdue { get; set; }
+    }
+}


### PR DESCRIPTION
Added a field for confirmation statement to company profile. Also added its corresponding class according to the format defined in the API:

`"confirmation_statement" : {
      "last_made_up_to" : "date",
      "next_due" : "date",
      "next_made_up_to" : "date",
      "overdue" : "boolean"
   }`