### PR TITLE
Fixing typos in README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var settings = new CompaniesHouseSettings(apiKey);
 We need to now create a `CompaniesHouseClient` - passing in the settings that we've just created.
 
 ```csharp
-vusing(ar client = new CompaniesHouseClient(settings))
+using(var client = new CompaniesHouseClient(settings))
 {
     // Do some work...
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
     only:
       - master
 
-  version: 4.0.0
+  version: 4.0.1
   install:
     - ps : .\environment-install.ps1
 


### PR DESCRIPTION
Per [this](https://stackoverflow.com/questions/50799399/companies-house-api-c-sharp) Stack Overflow question, a typo in the documentation was found.  Updating "vusing" to "using" and "ar" to "var".