### PR TITLE
Use case-sensitive newtonsoft.json reference

### DIFF
--- a/src/CompaniesHouse/CompaniesHouse.csproj
+++ b/src/CompaniesHouse/CompaniesHouse.csproj
@@ -34,12 +34,12 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="newtonsoft.json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
-    <PackageReference Include="newtonsoft.json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hello @kevbite  👋 

The loose casing of `newtonsoft.json` in `CompaniesHouse.csproj` is causing some errors for me when using this pacakge.

<img width="487" alt="screen shot 2019-01-23 at 12 41 50 pm" src="https://user-images.githubusercontent.com/496068/51572983-548b6180-1f0c-11e9-93dd-79afb80dce98.png">

It seems there are some inconsistencies in when package references are and aren't case-insensitive, and I seem to be hitting that.

I have tested this by changing the casing, building the package locally, referencing that package in my project and confirming the build error disappears, then reverting the casing change, rebuilding the package locally and confirming the error re-appears.

