### PR TITLE
Add company type "registered-overseas-entity"

### DIFF
--- a/src/CompaniesHouse/Response/CompanyType.cs
+++ b/src/CompaniesHouse/Response/CompanyType.cs
@@ -109,5 +109,8 @@ namespace CompaniesHouse.Response
         [EnumMember(Value = "united-kingdom-societas")]
         UnitedKingdomSocietas,
 
+        [EnumMember(Value = "registered-overseas-entity")]
+        RegisteredOverseasEntity,
+
     }
 }


### PR DESCRIPTION
We've just seen an exception when parsing a CH response (below). I hope this will fix it.

```
Error converting value "registered-overseas-entity" to type 'CompaniesHouse.Response.CompanyType'. Path 'company_type', line 1, position 4205.
Requested value 'registered-overseas-entity' was not found.
```

Note: This company type appears to be relatively new as it's the last listed on https://developer-specs.company-information.service.gov.uk/companies-house-public-data-api/resources/companysearch?v=latest