### PR TITLE
209 - add missing filing category and subcategory values

### DIFF
--- a/src/CompaniesHouse/Response/FilingCategory.cs
+++ b/src/CompaniesHouse/Response/FilingCategory.cs
@@ -83,5 +83,11 @@ namespace CompaniesHouse.Response
 
         [EnumMember(Value = "certificate")]
         Certificate,
+
+        [EnumMember(Value = "officer")]
+        Officer,
+
+        [EnumMember(Value = "social-landlord")]
+        SocialLandlord,
     }
 }

--- a/src/CompaniesHouse/Response/FilingSubcategory.cs
+++ b/src/CompaniesHouse/Response/FilingSubcategory.cs
@@ -89,5 +89,8 @@ namespace CompaniesHouse.Response
         
         [EnumMember(Value = "debenture")]
         Debenture,
+
+        [EnumMember(Value = "social-landlord")]
+        SocialLandlord,
     }
 }


### PR DESCRIPTION
Issue 209 - add in the following enum values;

FilingCategory
- officer
- social-landlord

FilingSubcategory
- social-landlord