### PR TITLE
Add date formatting (optional)

### DIFF
--- a/src/CompaniesHouse/Description/DescriptionProvider.cs
+++ b/src/CompaniesHouse/Description/DescriptionProvider.cs
@@ -1,13 +1,16 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
 namespace CompaniesHouse.Description
 {
     public class DescriptionProvider
     {
+        private const string _sourceDateFormat = "yyyy-MM-dd";
         private static readonly Regex _pattern = new Regex(@"({[a-zA-Z0-9.-_]*})");
+        private static readonly Regex _datePattern = new Regex(@"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$");
 
-        public static string GetDescription(string format, JObject values)
+        public static string GetDescription(string format, JObject values, string dateFormat = null)
         {
             if (values != null)
             {
@@ -19,7 +22,15 @@ namespace CompaniesHouse.Description
 
                     if (variableValue != null)
                     {
-                        format = format.Replace(placeHolder, variableValue.Value<string>());
+                        var value = variableValue.Value<string>();
+                        if (!string.IsNullOrEmpty(dateFormat) &&
+                            _datePattern.IsMatch(value))
+                        {
+                            var date = DateTime.ParseExact(value, _sourceDateFormat, CultureInfo.InvariantCulture);
+                            value = date.ToString(dateFormat);
+                        }
+
+                        format = format.Replace(placeHolder, value);
                     }
                 }
             }

--- a/tests/CompaniesHouse.Tests/DescriptionTests/DescriptionProviderTests.cs
+++ b/tests/CompaniesHouse.Tests/DescriptionTests/DescriptionProviderTests.cs
@@ -55,5 +55,48 @@ namespace CompaniesHouse.Tests.DescriptionTests
 
             result.Should().Be(@"some value: {nullvariable}");
         }
+
+        [Test]
+        public void GivenFormatAndMatchingDateVariableNoDateFormat()
+        {
+            var format = "some value: {variable}";
+            var values = JObject.Parse(@"{ ""variable"": ""2024-11-28"" }");
+            var result = DescriptionProvider.GetDescription(format, values);
+
+            result.Should().Be(@"some value: 2024-11-28");
+        }
+
+        [Test]
+        public void GivenFormatAndMatchingDateVariableWithDateFormat()
+        {
+            var format = "some value: {variable}";
+            var values = JObject.Parse(@"{ ""variable"": ""2024-11-28"" }");
+            var dateFormat = "dd-MMM-yyyy";
+            var result = DescriptionProvider.GetDescription(format, values, dateFormat);
+
+            result.Should().Be(@"some value: 28-Nov-2024");
+        }
+
+        [Test]
+        public void GivenFormatAndInvalidDateVariableWithDateFormat()
+        {
+            var format = "some value: {variable}";
+            var values = JObject.Parse(@"{ ""variable"": ""2024-20-28"" }");
+            var dateFormat = "dd-MMM-yyyy";
+            var result = DescriptionProvider.GetDescription(format, values, dateFormat);
+
+            result.Should().Be(@"some value: 2024-20-28");
+        }
+
+        [Test]
+        public void GivenFormatAndIsNotDateVariableWithDateFormat()
+        {
+            var format = "some value: {variable}";
+            var values = JObject.Parse(@"{ ""variable"": ""Value"" }");
+            var dateFormat = "dd-MMM-yyyy";
+            var result = DescriptionProvider.GetDescription(format, values, dateFormat);
+
+            result.Should().Be(@"some value: Value");
+        }
     }
 }


### PR DESCRIPTION
When calling the GetDescription method, some values from Companies House are dates. 

I've extended the GetDescription to pass in a date format.

When processing the value we check whether we have a date format, and whether the value is a date from Companies house formatted as yyyy-MM-dd. If it is, parse the date, then apply the passed in format.

Unit tests added.